### PR TITLE
Example how to make assertion more should.js way

### DIFF
--- a/src/assertions/assertion-builder.js
+++ b/src/assertions/assertion-builder.js
@@ -13,9 +13,9 @@ slice = Array.prototype.slice;
  */
 
 export function assertionBuilder(
-  name, 
-  assertFn, 
-  failMessageFn, 
+  name,
+  assertFn,
+  failMessageFn,
   wrapperBuilder = WrapperBuilder) {
 
   Assertion.add(name, function() {
@@ -27,5 +27,17 @@ export function assertionBuilder(
     };
 
     should(assertFn.apply(wrapper, args)).be.true(' ');
+  });
+}
+
+
+export function assertionBuilder1(name, assertFn, wrapperBuilder = WrapperBuilder) {
+  Assertion.add(name, function() {
+    const wrapper = wrapperBuilder(this.obj),
+      args = slice.call(arguments);
+
+    args.unshift(wrapper);
+
+    assertFn.apply(this, args);
   });
 }

--- a/src/assertions/attr.js
+++ b/src/assertions/attr.js
@@ -1,15 +1,18 @@
-import { assertionBuilder } from './assertion-builder';
-import assertKeyValue from '../assert-key-value';
+import { assertionBuilder1 } from './assertion-builder';
+import should from 'should';
 
-assertionBuilder(
-  'attr', 
-  function (expectedKey, expectedValue) {
-    return assertKeyValue(this.attr(expectedKey), expectedValue);
-  },
-  function (expectedKey, expectedValue) {
-    if(arguments.length === 2 && typeof this.attr(expectedKey) !== 'undefined')
-      return `expected '${this.name()}' attribute '${expectedKey}' to have value '${expectedValue}', instead found '${this.attr(expectedKey)}'`;
-
-    return `expected '${this.name()}' to have attribute '${expectedKey}'`;
+assertionBuilder1(
+  'attr',
+  function (wrapper, key, value) {
+    this.params = {
+      obj: wrapper.name(),
+      operator: `to have attribute '${key}'`
+    };
+    this.obj = wrapper.attr(key);//TODO
+    should(this.obj).be.not.undefined();
+    if(value !== void(0)) {
+      this.params.operator += ` with value '${should.format(value)}' (found '${should.format(this.obj)}')`;
+      should(this.obj).be.equal(value);
+    }
   }
 );

--- a/src/assertions/attr.spec.js
+++ b/src/assertions/attr.spec.js
@@ -26,7 +26,7 @@ describe('Should enzyme add attr feature', () => {
       });
 
       it('should have attribute "title"', () => {
-        wrapper.should.have.attr('title');
+        wrapper.should.not.have.attr('title');
       });
 
       it('should have attribute "title" with value "enzyme"', () => {
@@ -54,6 +54,10 @@ describe('Should enzyme add attr feature', () => {
       it('should see useful error message for incorrect attribute', () => {
         (() => wrapper.should.have.attr('pizza', 'stuff'))
         .should.throwError(/expected '(div|AttrFixture)' to have attribute 'pizza'/);
+      });
+
+      it('should allow to change assertions for values', () => {
+        wrapper.should.have.attr('title').which.is.not.empty();
       });
     });
   });


### PR DESCRIPTION
Do not need to merge this. It is just example how to make assertions more should.js way.
In attr assertion case message changed to look like:
```
'expected 'div' to have attribute 'title' with value ''stuff' (found ''enzyme'')'
    expected 'enzyme' to be 'stuff''

```

probably this require some cleaning.

Thoughts?